### PR TITLE
Add support for nuke7

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Build Schema",
   "$ref": "#/definitions/build",
+  "title": "Build Schema",
   "definitions": {
     "build": {
       "type": "object",
@@ -12,18 +12,6 @@
         "Continue": {
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
-        },
-        "DanglCiCdTeamsWebhookUrl": {
-          "type": "string"
-        },
-        "DocuApiKey": {
-          "type": "string"
-        },
-        "DocuBaseUrl": {
-          "type": "string"
-        },
-        "GitHubAuthenticationToken": {
-          "type": "string"
         },
         "Help": {
           "type": "boolean",
@@ -36,6 +24,7 @@
             "AppVeyor",
             "AzurePipelines",
             "Bamboo",
+            "Bitbucket",
             "Bitrise",
             "GitHubActions",
             "GitLab",
@@ -62,9 +51,6 @@
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
         },
-        "NuGetApiKey": {
-          "type": "string"
-        },
         "Partition": {
           "type": "string",
           "description": "Partition to use on CI"
@@ -79,12 +65,6 @@
           "items": {
             "type": "string"
           }
-        },
-        "PublicMyGetApiKey": {
-          "type": "string"
-        },
-        "PublicMyGetSource": {
-          "type": "string"
         },
         "Root": {
           "type": "string",

--- a/build/.build.csproj
+++ b/build/.build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace></RootNamespace>
     <IsPackable>False</IsPackable>
@@ -11,13 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="docfx.console" Version="2.59.3">
+    <PackageReference Include="docfx.console" Version="2.59.4">
       <ExcludeAssets>build</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="Nuke.Common" Version="6.1.2" />
+    <PackageReference Include="Nuke.Common" Version="7.0.0" />
     <PackageReference Include="Nuke.GitHub" Version="3.0.0" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.10.3]" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1">
+    <PackageReference Include="xunit.runner.console" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Nuke.WebDocu/Nuke.WebDocu.csproj
+++ b/src/Nuke.WebDocu/Nuke.WebDocu.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
     <Description>Deploy to WebDocu with NUKE Build</Description>
     <Authors>Georg Dangl</Authors>
     <Copyright>(c) $([System.DateTime]::Now.Year) Georg Dangl</Copyright>
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.1.2" />
+    <PackageReference Include="Nuke.Common" Version="7.0.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
   </ItemGroup>
   

--- a/test/Nuke.WebDocu.Tests/Nuke.WebDocu.Tests.csproj
+++ b/test/Nuke.WebDocu.Tests/Nuke.WebDocu.Tests.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="XunitXml.TestLogger" Version="3.0.70" />
+    <PackageReference Include="XunitXml.TestLogger" Version="3.0.78" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I was not able to get .build csproj to work without commenting out Nuke.Github package since the upgrade to Nuke 7.0.0 breaks it.

After commenting any Nuke.GitHub references I've verified that running `nuke` runs successfully, haven't tried the other actions but the change seems minimal enough.

I also ran unit tests and they pass.